### PR TITLE
Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.o
 *.out
 kurses
-test
+*test

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,14 @@ menu.o: menu.c menu.h
 	clang -c menu.c
 main.o: main.c menu.h
 	clang -c main.c
-test: testmenu.o menu.o
+tests: menutest cursortest
+menutest: testmenu.o menu.o
 	clang testmenu.o menu.o -o test -lncurses
 testmenu.o: testmenu.c menu.h
 	clang -c testmenu.c
+cursortest: testcursor.o menu.o
+	clang testcursor.o menu.o -o ctest -lncurses
+testcursor.o: testcursor.c menu.h
+	clang -c testcursor.c
 clean:
 	rm *.o kurses test

--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ int main(){
 - similar problem as yesterday, but with whole submenu instead of just entries
 - each submenu is getting unique entries, but when we add it to the menu, the old ones get overwritten
 - testmenu.c results in 3 menus with the same entries (I'm not making a new pointer successfully somewhere where I think I am...)
+
+> submenu size can't be calculated with sizeof because it was defined with ** syntax, you need to count the entries in a loop in [menu.c](./menu.c)

--- a/main.c
+++ b/main.c
@@ -11,6 +11,8 @@ int main(){
     int ch;
 
     initscr();
+    curs_set(0);
+    
     initializeCursor(&cursor);
     initializeMenu(&menu);
 

--- a/menu.c
+++ b/menu.c
@@ -4,8 +4,12 @@ void addSubMenu(char *name, Menu *menu, int pos, char **items) {
 
     Menu *temp = malloc(sizeof(Menu));
     int size=0;    
-
-    while(items[size]) size++;
+    int width=0;
+    while(items[size]){
+        if(width < strlen(items[size]))
+            width = strlen(items[size]);
+        size++;
+    }   
 
     temp->items = malloc(sizeof(Item) * size);
 
@@ -14,29 +18,38 @@ void addSubMenu(char *name, Menu *menu, int pos, char **items) {
         cur->name = items[i];
         temp->items[i] = cur;
     }
+
     temp->length = size;
+    temp->width = width;
+    temp->offset = menu->offset+menu->width+5;
+    temp->win=derwin(stdscr,size,width,1,temp->offset);
     menu->items[pos]->submenu = temp;
 }
 
+/* initalize a cursor with depth of 2 pointing to (0,0) */
 void initializeCursor(Cursor *cursor) {
     cursor->sel[0] = cursor->sel[1] = 0;
     cursor->depth=0;
 }
 
-void initializeMenu(Menu *menu) {
+/* adds title, calculates size, and adds submenus to the given menu */
+void initializeMenu(Menu *menu, int offset) {
     menu->title = "Main";
     int size = sizeof items / sizeof (items[0]);
     menu->length = size;
     menu->items = malloc(sizeof(Item) * size); 
-
+    menu->width = 0;
+    menu->offset = 3;
     
     // build menu
     for(int i=0;i<size;i++) {
         Item *cur = malloc(sizeof(Item));
+        if (menu->width < strlen(items[i])) {
+            menu->width = strlen(items[i]);
+        }
         cur->name = items[i];
         menu->items[i] = cur;
     }
-
 
     addSubMenu("Jobs", menu, 0, scripts);
     addSubMenu("Manifests", menu, 1, kinds);

--- a/menu.c
+++ b/menu.c
@@ -24,8 +24,15 @@ void addSubMenu(char *name, Menu *menu, int pos, char **items) {
     }
 
     temp->length = size;
-    cursor->offset = menu->offset+menu->width+3;
-    cursor->win = derwin(stdscr,size,3,1,cursor->offset);
+    cursor->offset = menu->offset+menu->width+1;
+
+    //size must be at least the same as the main menu size
+    //otherwise the window is too small to draw the connecting line
+    if(size>6){
+        cursor->win = derwin(stdscr,size,3,1,cursor->offset);
+    } else {
+        cursor->win = derwin(stdscr,6,3,1,cursor->offset);
+    }
     temp->offset = cursor->offset+3;
     temp->win = derwin(stdscr,size,temp->width,1,temp->offset);
     temp->cursor = cursor;

--- a/menu.h
+++ b/menu.h
@@ -10,13 +10,11 @@ typedef struct Item Item;
 typedef struct Cursor Cursor;
 
 void addSubMenu(char*,Menu*,int,char**);
-void initializeMenu(Menu*,int);
-void initializeCursor(Cursor*);
+void initializeMenu(Menu*);
 
 struct Cursor {
-    int sel[2];
-    int depth;
-    char *selection;
+    int sel;
+    int offset;
     WINDOW *win;
 };
 
@@ -34,6 +32,7 @@ struct Menu {
     int offset;
     Item **items;
     WINDOW *win;
+    Cursor *cursor;
 };
 
 static char *items[6] = {

--- a/menu.h
+++ b/menu.h
@@ -10,25 +10,28 @@ typedef struct Item Item;
 typedef struct Cursor Cursor;
 
 void addSubMenu(char*,Menu*,int,char**);
-void initializeMenu(Menu*);
+void initializeMenu(Menu*,int);
 void initializeCursor(Cursor*);
 
 struct Cursor {
     int sel[2];
     int depth;
-    char* selection;
-    WINDOW **cwin;
+    char *selection;
+    WINDOW *win;
 };
 
 struct Item {
     char *name;
     void (*action)(int);
     Menu *submenu;
+    WINDOW *win;
 };
 
 struct Menu {
     char *title;
     int length;
+    int width;
+    int offset;
     Item **items;
     WINDOW *win;
 };

--- a/testcursor.c
+++ b/testcursor.c
@@ -2,6 +2,7 @@
 
 void drawCursor(Cursor*);
 void drawMenu(Menu*);
+void drawLines(Menu*,Menu*);
 
 int main(){
 
@@ -32,6 +33,7 @@ int main(){
         wrefresh(titlebar);
 
         drawCursor(cursor);
+        if (level > 0) drawLines(&menu,activeMenu);
 
         Menu *next;
         ch = wgetch(cursor->win);
@@ -46,8 +48,8 @@ int main(){
                 break;
             case KEY_LEFT:
                 if(level>0){
-                    werase(menu.items[pos[0]]->submenu->win);
-                    wrefresh(menu.items[pos[0]]->submenu->win);
+                    werase(menu.items[menu.cursor->sel]->submenu->win);
+                    wrefresh(menu.items[menu.cursor->sel]->submenu->win);
                     werase(cursor->win);
                     wrefresh(cursor->win);
                     level--;
@@ -79,8 +81,34 @@ int main(){
 //wgetch does an implicit refresh so we don't need one in this function
 void drawCursor(Cursor *cursor){
     werase(cursor->win);
-    mvwaddstr(cursor->win,cursor->sel,0, "->");
-    wrefresh(cursor->win);
+    mvwaddstr(cursor->win,cursor->sel,1, ">");
+}
+
+void drawLines(Menu *left, Menu *right){
+    int pos1 = left->cursor->sel;
+    int pos2 = right->cursor->sel;
+
+    WINDOW *r=right->cursor->win;
+    // werase(r);
+    if(pos1<pos2) {
+        wmove(r,pos1,0);
+        waddch(r,A_ALTCHARSET | ACS_URCORNER);
+        wmove(r,pos1+1,0);
+        wvline(r,0,pos2-pos1-1);
+        wmove(r,pos2,0);
+        waddch(r,A_ALTCHARSET | ACS_LLCORNER);
+    }else if(pos2<pos1){
+        wmove(r,pos2,0);
+        waddch(r,A_ALTCHARSET | ACS_ULCORNER);
+        wmove(r,pos2+1,0);
+        wvline(r,0,pos1-pos2);
+        wmove(r,pos1,0);
+        waddch(r,A_ALTCHARSET | ACS_LRCORNER);
+    }else{
+        wmove(r,pos2,0);
+        whline(r,0,1);
+    }
+
 }
 
 void drawMenu(Menu *menu){

--- a/testcursor.c
+++ b/testcursor.c
@@ -62,7 +62,7 @@ int main(){
                 if(level<1){
                     level++;
                 
-                    next = menu.items[pos[level]]->submenu;
+                    next = menu.items[cursor->sel]->submenu;
                     drawMenu(next);
                     activeMenu=next;
                     cursor=activeMenu->cursor;

--- a/testcursor.c
+++ b/testcursor.c
@@ -1,0 +1,99 @@
+#include "menu.h"
+
+void drawCursor(Cursor*);
+void drawMenu(Menu*);
+
+int main(){
+
+    Menu menu;
+    Cursor cursor;
+    WINDOW *cwin;
+    WINDOW *mwin;
+    WINDOW *titlebar;
+    int ch;
+
+    initscr();
+    // curs_set(0);
+    refresh();
+
+    initializeCursor(&cursor);
+    initializeMenu(&menu,3);
+
+    cwin = derwin(stdscr,menu.length,3,1,0);
+    cursor.win = cwin;
+
+    mwin = derwin(stdscr,menu.length,menu.width,1,3);
+    menu.win = mwin;
+
+    titlebar = derwin(stdscr,1,COLS,0,0);
+
+    keypad(cursor.win,TRUE);
+    drawMenu(&menu);
+    do {
+        curs_set(0);
+        int pos = cursor.sel[0];
+        int level = cursor.depth;
+        move(0,0);
+        werase(titlebar);
+        wprintw(titlebar,"sel[0]: %d, sel[1]: %d, level: %d, length: %d",cursor.sel[0],cursor.sel[1],level, menu.length);
+        wrefresh(titlebar);
+
+        drawCursor(&cursor);
+
+        ch = wgetch(cursor.win);
+        switch(ch) {
+            case KEY_DOWN:
+                if (level==1){
+                    Item *item = menu.items[pos];
+                    if (cursor.sel[1] < item->submenu->length-1)
+                        cursor.sel[1]++;
+                } else {
+                    if (cursor.sel[0] < menu.length-1)
+                        cursor.sel[0]++;
+                }
+                break;
+            case KEY_UP:
+                if (cursor.sel[level] > 0) cursor.sel[level]--;
+                break;
+            case KEY_LEFT:
+                if (level > 0){
+                    cursor.depth--;
+                    werase(menu.items[pos]->submenu->win);
+                    wrefresh(menu.items[pos]->submenu->win);
+                } 
+                break;
+            case KEY_RIGHT:
+                if (level < 1) cursor.depth++;
+                if ( pos+1 > menu.items[pos]->submenu->length )
+                    cursor.sel[cursor.depth]=menu.items[pos]->submenu->length - 1;
+                else
+                    cursor.sel[cursor.depth]=pos;
+                drawMenu(menu.items[pos]->submenu);
+                break;
+            default:
+                break;
+        }
+    } while (ch != 27);
+
+
+    endwin();
+    return(0);
+}
+
+//wgetch does an implicit refresh so we don't need one in this function
+void drawCursor(Cursor *cursor){
+    werase(cursor->win);
+    mvwaddstr(cursor->win,cursor->sel[0],0, "->");
+}
+
+void drawMenu(Menu *menu){
+    werase(menu->win);
+    for (int i=0;i<menu->length;i++) {
+        mvwaddstr(
+            menu->win,
+            i,0,
+            menu->items[i]->name
+        );
+    }
+    wrefresh(menu->win);
+}

--- a/testmenu.c
+++ b/testmenu.c
@@ -8,39 +8,51 @@ void levelTwo(int*, char*);
 int main(){
 
     Menu menu;
-    Cursor cursor;
+    Cursor *cursor;
+    cursor = malloc(sizeof(Cursor));
     menu.title = "Main";
-    cursor.depth = 0;
     menu.length = 6;
+    int i;
 
     menu.items = malloc(sizeof(Item) * menu.length); 
 
     //build menu
-    printf("Title: %s\n",menu.title);
-    printf("Size: %d\n",menu.length);
+    // printf("Title: %s\n",menu.title);
+    // printf("Size: %d\n",menu.length);
 
-    for(int i=0;i<menu.length;i++) {
-        Item *cur = malloc(sizeof(Item));
-        cur->name = items[i];
-        menu.items[i] = cur;
-    }
+    // for(int i=0;i<menu.length;i++) {
+    //     Item *cur = malloc(sizeof(Item));
+    //     cur->name = items[i];
+    //     menu.items[i] = cur;
+    // }
 
-    addSubMenu("Jobs", &menu, 0, scripts);
-    addSubMenu("Manifests", &menu, 1, kinds);
-    addSubMenu("tools", &menu, 2, tools);
-    addSubMenu("Options", &menu, 3, options);
-    addSubMenu("Context", &menu, 4, context);
-    addSubMenu("Kubectl", &menu, 5, kubectl);
-    
+    // addSubMenu("Jobs", &menu, 0, scripts);
+    // addSubMenu("Manifests", &menu, 1, kinds);
+    // addSubMenu("tools", &menu, 2, tools);
+    // addSubMenu("Options", &menu, 3, options);
+    // addSubMenu("Context", &menu, 4, context);
+    // addSubMenu("Kubectl", &menu, 5, kubectl);
+
+    initializeMenu(&menu);
+
+    //print cursor
+    printf("Menu Cursor:\n");
+    printf("  sel:%d, offset:%d\n",cursor->sel,cursor->offset);
+
     //print menu items
-    printf("Menu item names:\n");
-    for(int i=0;i<menu.length;i++) {
+    printf("Menu items:\n");
+    for(i=0;i<menu.length;i++) {
         Item *item = menu.items[i];
         printf("%s:\n",item->name);
         if(item->submenu) {
-            for(int k=0;k<item->submenu->length;k++) {
-                Item *sub = item->submenu->items[k];
-                printf("\t- %s\n",sub->name);
+            Menu *sub = item->submenu;
+            printf("  length=%d\n",sub->length);
+            printf("  width=%d\n",sub->width);
+            printf("    Submenu Cursor:\n");
+            printf("    sel:%d, offset:%d\n",sub->cursor->sel,sub->cursor->offset);
+            for(int k=0;k<sub->length;k++) {
+                Item *entry = sub->items[k];
+                printf("\t- %s\n",entry->name);
             }
         }
     }


### PR DESCRIPTION
Updates main window logic.
- Fix blinking by favoring werase over clear, and splitting the standard screen into working subwindows.
This allows us to clear just the need portion of the screen.

- Moves Cursor Struct into Menu struct
This gives us a clear way of tracking position on all the submenus, and makes drawing the cursor more straight forward (clear the cursor window and draw the active menu's cursor)

- Utilize vline and hline functions
in the draw lines function, instead of checking if each position is between the two cursors, simply draw a line from the first cursor down using distance.

Closes #7 